### PR TITLE
Display event time range on hover

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -172,6 +172,15 @@ html, body {
   text-overflow: ellipsis;
   margin-top: 20px; /* leave space for type badge */
 }
+/* Hidden time range that appears on hover */
+.time-range {
+  display: none;
+  font-size: 0.7rem;
+  margin-top: 2px;
+}
+.event-block:hover .time-range {
+  display: block;
+}
 /* White badge with event type at top-left */
 .event-type-badge {
   position: absolute;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -571,6 +571,7 @@ function EventBlock({ dayName, eventObj, top, height, adminMode, isSelected, onE
     >
       <div className="event-type-badge">{eventObj.type}</div>
       <span className="event-title">{eventObj.title}</span>
+      <div className="time-range">{eventObj.start} - {eventObj.end}</div>
       {adminMode && isSelected && (
         <>
           <div className="drag-handle top-handle" onMouseDown={handleTopDragStart}></div>


### PR DESCRIPTION
## Summary
- show start and end times inside each event block
- hide the time range until the block is hovered

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684fc85ffa20832081b51e0613d55917